### PR TITLE
Add support for custom rn-cli.config.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,9 +6,11 @@
     "node": true,
   },
   "rules": {
+    "arrow-parens": 0,
     "quotes": ["error", "single", { "avoidEscape": true }],
     "func-style": 0,
     "no-multiple-empty-lines": 0,
-    "no-console": 0
+    "no-console": 0,
+
   }
 }

--- a/src/packager/project.config.js
+++ b/src/packager/project.config.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const projectConfigPath = `${process.cwd()}/rn-cli.config.js`;
+
+if (fs.existsSync(projectConfigPath)) {
+  module.exports = require(projectConfigPath);
+} else {
+  module.exports = {};
+}

--- a/src/packager/rn-cli.config.js
+++ b/src/packager/rn-cli.config.js
@@ -1,18 +1,24 @@
 const blacklist = require(`${process.cwd()}/node_modules/react-native/packager/blacklist`);
 const whackage = require('../util/config').read();
+const projectConfig = require('./project.config');
+
 const log = require('../util/log');
-module.exports = {
-  getBlacklistRE(platform) {
-    const modules = Object
-      .keys(whackage.dependencies)
-      .map((packageName) =>
-        new RegExp(`node_modules/${packageName}/node_modules/.*`)
-      );
+module.exports = Object.assign({}, projectConfig, {
+  getBlacklistRE(platform = []) {
+    // blacklist dependencies' node modules to avoid duplicate module definitions
+    const modules = Object.keys(whackage.dependencies).map(
+      packageName => new RegExp(`node_modules/${packageName}/node_modules/.*`)
+    );
+
+    const combined = platform.concat(modules);
 
     log.info(`blacklisted ${modules.length} dependencies`);
-    return blacklist(
-      platform,
-      modules
-    );
+
+    // if the user has provided their own blacklist, use that instead
+    if (typeof projectConfig.getBlacklistRE === 'function') {
+      return projectConfig.getBlacklistRE(combined);
+    } else {
+      return blacklist(combined);
+    }
   }
-};
+});


### PR DESCRIPTION
Solves https://github.com/FormidableLabs/whackage/issues/7

## API

The only requirements are, that the user's config needs to be called `/rn-cli.config.js` (in the project root), and the `getBlackListRE` method must take an optional array of "default" modules to blacklist, and pass those to `blacklist`. Something like:

```js
const blacklist = require('react-native/packager/blacklist');

module.exports = {
  getBlacklistRE(defaults = []) {
    const modulesToBlacklist = [
      /* ... your deps */
    ];

    return blacklist(defaults.concat(modulesToBlacklist));
  }
};
```

All the other [custom config methods](https://github.com/facebook/react-native/blob/8f03969011ccfdc67ab97ce49ace18e70a828b47/packager/rn-cli.config.js#L16-L46) are passed through and should work unmodified.

## Testing notes

The easiest way to test this is:
```sh
git clone git@github.com:FormidableLabs/whackage.git
git checkout feature/support-custom-rn-cli.js
npm install
npm link
```

And in your own project:
```sh
npm link whackage
```