### PR TITLE
add run argument to run command

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -17,7 +17,7 @@ module.exports = function run({ npmScript }) {
   commandExists('rsync', (error, rsyncExists) => {
     if (!error && rsyncExists) {
       startServer();
-      spawn('npm', [npmScript, '--', '--config', cliConfigPath], (code) => {
+      spawn('npm', ['run', npmScript, '--', '--config', cliConfigPath], (code) => {
         process.exit(code);
       });
 


### PR DESCRIPTION
the docs say that I'm able to call `whack run server:dev` which is not true. there is a specific set of commands which can be run without the `run` as second argument