### PR TITLE
add NPM 5 support

### DIFF
--- a/src/util/assert.js
+++ b/src/util/assert.js
@@ -43,14 +43,9 @@ function isOwnDependency(packageName) {
   }
 }
 
-function isNotSymlinked(packageName) {
+function isSymlinked(packageName) {
   const packagePath = path.resolve(process.cwd(), 'node_modules', packageName);
-  if (isSymlink.sync(packagePath)) {
-    exitWith(
-      `Package ${packageName} appears to be symlinked. ` +
-      'Overwriting symlinks is not currently supported. Unlink package and try again.'
-    );
-  }
+  return isSymlink.sync(packagePath)
 }
 
 module.exports = {
@@ -59,5 +54,5 @@ module.exports = {
   whackageJsonDoesntExist,
   isValidModule,
   isOwnDependency,
-  isNotSymlinked
+  isSymlinked
 };

--- a/src/util/start-server.js
+++ b/src/util/start-server.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs-extra');
 const chokidar = require('chokidar');
 const assert = require('./assert');
 const syncAll = require('./sync-all');
@@ -32,7 +33,10 @@ module.exports = function startServer() {
   // initial sync
   for (const key in packageLookup) {
     if (packageLookup.hasOwnProperty(key)) {
-      assert.isNotSymlinked(packageLookup[key]);
+      if (assert.isSymlinked(packageLookup[key])) {
+        const packagePath = path.resolve(process.cwd(), 'node_modules', packageLookup[key]);
+        fs.removeSync(packageLookup[key]);
+      }
       syncAll(ROOT_PATH, key, packageLookup[key], exclude);
     }
   }

--- a/src/util/start-server.js
+++ b/src/util/start-server.js
@@ -35,7 +35,7 @@ module.exports = function startServer() {
     if (packageLookup.hasOwnProperty(key)) {
       if (assert.isSymlinked(packageLookup[key])) {
         const packagePath = path.resolve(process.cwd(), 'node_modules', packageLookup[key]);
-        fs.removeSync(packageLookup[key]);
+        fs.removeSync(packagePath);
       }
       syncAll(ROOT_PATH, key, packageLookup[key], exclude);
     }


### PR DESCRIPTION
This will still create symlinks as part of `whack link <package_name>`, which *will break* running the RN Packager directly.

That shouldn't be too much of an issue though, as from there users should be doing `whack run start` ( / similar).

Once the server is running, we `removeSync` any symlinks we encounter (so we don't break the RN Bundler), and pass that directory to `rsync` as before.