### PR TITLE
added ability to pass arguments to the run command

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ yargs
     require('./src/commands/install')
   )
   .command(
-    'run <npmScript>',
+    'run <npmScript> [arguments...]',
     'start whack server',
     {},
     require('./src/commands/run')

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -17,7 +17,7 @@ module.exports = function run(opts) {
   commandExists('rsync', (error, rsyncExists) => {
     if (!error && rsyncExists) {
       startServer();
-      spawn('npm', ['run', opts.npmScript, '--', '--config', cliConfigPath], (code) => {
+      spawn('npm', ['run', opts.npmScript, '--', '--config', cliConfigPath].concat(opts.arguments || []), (code) => {
         process.exit(code);
       });
 


### PR DESCRIPTION
I was missing the ability to pass arguments to the run command (like --reset-cache). This PR enables the functionality. You can now run whack run start -- --reset-cache and it passes the --reset-cache to the npm command.